### PR TITLE
Refactor/body responses

### DIFF
--- a/src/features/users/controllers/register.controller.ts
+++ b/src/features/users/controllers/register.controller.ts
@@ -18,7 +18,6 @@ export const registerUserController = async (
 
     const result = await registerUserService(validatedData);
     res.status(201).json({
-      status: result.status,
       message: result.message
     });
   } catch (error) {
@@ -48,7 +47,6 @@ export const registerAdminController = async (
     }
     const result = await registerAdminService(validatedData, req.user.role);
     res.status(201).json({
-      status: result.status,
       message: result.message
     });
   } catch (error) {

--- a/src/utils/errors/api-error.ts
+++ b/src/utils/errors/api-error.ts
@@ -23,25 +23,25 @@ export class UnauthorizedError extends ApiError {
 }
 
 export class ForbiddenError extends ApiError {
-  constructor(message: string = 'Forbidden') {
-    super(403, message);
+  constructor(message: string = 'Forbidden', details?: string[]) {
+    super(403, message, details);
   }
 }
 
 export class NotFoundError extends ApiError {
-  constructor(message: string = 'Resource not found') {
-    super(404, message);
+  constructor(message: string = 'Resource not found', details?: string[]) {
+    super(404, message, details);
   }
 }
 
 export class ConflictError extends ApiError {
-  constructor(message: string) {
-    super(409, message);
+  constructor(message: string, details?: string[]) {
+    super(409, message, details);
   }
 }
 
 export class InternalServerError extends ApiError {
-  constructor(message: string = 'Internal server error') {
-    super(500, message);
+  constructor(message: string = 'Internal server error', details?: string[]) {
+    super(500, message, details);
   }
 }

--- a/src/utils/errors/error-handler.middleware.ts
+++ b/src/utils/errors/error-handler.middleware.ts
@@ -13,7 +13,6 @@ export const errorHandler: ErrorRequestHandler = (
   // Handle Yup validation errors
   if (error instanceof ValidationError) {
     res.status(400).json({
-      status: 400,
       message: 'Validation Error',
       details: error.errors
     });
@@ -22,12 +21,11 @@ export const errorHandler: ErrorRequestHandler = (
 
   // Handle our custom API errors
   if (error instanceof ApiError) {
-    const response: { status: number; message: string; details?: any } = {
-      status: error.status,
+    const response: { message: string; details?: any } = {
       message: error.message
     };
     // Only include details if they exist and it's not an unauthorized error
-    if (error.details && error.status !== 401) {
+    if (error.details) {
       response.details = error.details;
     }
     res.status(error.status).json(response);
@@ -37,7 +35,6 @@ export const errorHandler: ErrorRequestHandler = (
   // Handle Firebase auth errors
   if (error.name === 'FirebaseAuthError') {
     res.status(401).json({
-      status: 401,
       message: 'Invalid or missing Firebase token',
       details: error.message
     });
@@ -46,7 +43,6 @@ export const errorHandler: ErrorRequestHandler = (
 
   // Handle unknown errors
   res.status(500).json({
-    status: 500,
     message: 'Internal Server Error',
     details: process.env.NODE_ENV === 'development' ? error.message : undefined
   });

--- a/test-api/controllers/register.controller.test.ts
+++ b/test-api/controllers/register.controller.test.ts
@@ -73,7 +73,6 @@ describe('Register Controller Integration Tests', () => {
         .expect(201);
 
       expect(response.body).toEqual({
-        status: 201,
         message: 'User registered successfully.'
       });
     });
@@ -93,7 +92,6 @@ describe('Register Controller Integration Tests', () => {
         .expect(409);
 
       expect(response.body).toEqual({
-        status: 409,
         message: 'Email already registered'
       });
     });
@@ -124,7 +122,6 @@ describe('Register Controller Integration Tests', () => {
         .expect(201);
 
       expect(response.body).toEqual({
-        status: 201,
         message: 'Admin registered successfully.'
       });
     });
@@ -135,7 +132,6 @@ describe('Register Controller Integration Tests', () => {
         .send(validAdminData)
         .expect(401)
         .expect({
-          status: 401,
           message: 'Unauthorized'
         });
     });

--- a/test-api/middleware/error-handler.middleware.test.ts
+++ b/test-api/middleware/error-handler.middleware.test.ts
@@ -29,7 +29,6 @@ describe('Error Handler Middleware', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(400);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      status: 400,
       message: 'Validation Error',
       details: validationError.errors,
     });
@@ -47,13 +46,12 @@ describe('Error Handler Middleware', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(404);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      status: 404,
       message: 'Not Found',
       details: ['Invalid ID provided'],
     });
   });
 
-  it('should handle ApiError without details for 401 status', () => {
+  it('should handle Unauthorized Error with details for 401 status', () => {
     const apiError = new ApiError(401, 'Unauthorized', ['Invalid token']);
     
     errorHandler(
@@ -65,9 +63,8 @@ describe('Error Handler Middleware', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      status: 401,
-      message: 'Unauthorized'
-      // No details included for 401 errors
+      message: 'Unauthorized',
+      details: ['Invalid token']
     });
   });
 
@@ -84,7 +81,6 @@ describe('Error Handler Middleware', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      status: 401,
       message: 'Invalid or missing Firebase token',
       details: 'Invalid token',
     });
@@ -103,7 +99,6 @@ describe('Error Handler Middleware', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(500);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      status: 500,
       message: 'Internal Server Error',
       details: 'Something went wrong',
     });
@@ -122,7 +117,6 @@ describe('Error Handler Middleware', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(500);
     expect(mockResponse.json).toHaveBeenCalledWith({
-      status: 500,
       message: 'Internal Server Error',
       details: undefined,
     });


### PR DESCRIPTION
This pull request involves several changes to remove the `status` field from various response objects and enhance error handling by adding optional `details` to error constructors. The most important changes include updates to controllers, error handling middleware, and related tests.

Changes to controllers:

* [`src/features/users/controllers/register.controller.ts`](diffhunk://#diff-bd42aaf3ec853c05221abccb414aadc200b3bb59ee8a9a760f4254c143d98b21L21): Removed the `status` field from the JSON response in `registerUserController` and `registerAdminController`. [[1]](diffhunk://#diff-bd42aaf3ec853c05221abccb414aadc200b3bb59ee8a9a760f4254c143d98b21L21) [[2]](diffhunk://#diff-bd42aaf3ec853c05221abccb414aadc200b3bb59ee8a9a760f4254c143d98b21L51)

Enhancements to error handling:

* [`src/utils/errors/api-error.ts`](diffhunk://#diff-2e5b9f5aa0c071c9a9b4e77cc3b6d2306a1e80f7db8cfd67bbbec0d01a9fed6eL26-R45): Modified error constructors to accept an optional `details` parameter in `ForbiddenError`, `NotFoundError`, `ConflictError`, and `InternalServerError` classes.
* [`src/utils/errors/error-handler.middleware.ts`](diffhunk://#diff-30c45fd10d893a7b13285b67fa23c0f9972ec73b37de4d903a2eae819ce8d034L16): Removed the `status` field from the JSON response and updated the error handling logic to include `details` where applicable. [[1]](diffhunk://#diff-30c45fd10d893a7b13285b67fa23c0f9972ec73b37de4d903a2eae819ce8d034L16) [[2]](diffhunk://#diff-30c45fd10d893a7b13285b67fa23c0f9972ec73b37de4d903a2eae819ce8d034L25-R28) [[3]](diffhunk://#diff-30c45fd10d893a7b13285b67fa23c0f9972ec73b37de4d903a2eae819ce8d034L40) [[4]](diffhunk://#diff-30c45fd10d893a7b13285b67fa23c0f9972ec73b37de4d903a2eae819ce8d034L49)

Updates to tests:

* [`test-api/controllers/register.controller.test.ts`](diffhunk://#diff-bf040b77583cd8596f5c7f2b70b49d41c7ac40ac72a0be0fe615cc3fc7dbd5d6L76): Removed the `status` field from the expected response bodies in the integration tests for the register controller. [[1]](diffhunk://#diff-bf040b77583cd8596f5c7f2b70b49d41c7ac40ac72a0be0fe615cc3fc7dbd5d6L76) [[2]](diffhunk://#diff-bf040b77583cd8596f5c7f2b70b49d41c7ac40ac72a0be0fe615cc3fc7dbd5d6L96) [[3]](diffhunk://#diff-bf040b77583cd8596f5c7f2b70b49d41c7ac40ac72a0be0fe615cc3fc7dbd5d6L127) [[4]](diffhunk://#diff-bf040b77583cd8596f5c7f2b70b49d41c7ac40ac72a0be0fe615cc3fc7dbd5d6L138)
* [`test-api/middleware/error-handler.middleware.test.ts`](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L32): Updated the error handler middleware tests to remove the `status` field and verify the `details` field where applicable. [[1]](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L32) [[2]](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L50-R54) [[3]](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L68-R67) [[4]](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L87) [[5]](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L106) [[6]](diffhunk://#diff-5f88a6af198820ce2e8fd170b25e71aedb16ef8cfe516f0cec72bf83bb2d9829L125)