### PR TITLE
Feature/cu 86a7ky9pz send recover password link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "cross-env": "^7.0.3",
         "firebase-admin": "^13.2.0",
+        "firebase-admin-mock": "^0.0.10",
         "jest": "^29.7.0",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.14.1",
@@ -4079,6 +4080,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/email-validator": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.2.3.tgz",
+      "integrity": "sha512-WZmY6vj6bAWUzr1P2OmRkw4E3FWwdnKxWG/Ssfvr+kp+0leuXzsX2EHNwjg8+KW2DfAiFWiV+jn5n1P7TlE7lw==",
+      "dev": true,
+      "engines": {
+        "node": ">4.0"
+      }
+    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
@@ -4862,6 +4872,19 @@
         "@google-cloud/storage": "^7.14.0"
       }
     },
+    "node_modules/firebase-admin-mock": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/firebase-admin-mock/-/firebase-admin-mock-0.0.10.tgz",
+      "integrity": "sha512-Y1bn/6NdV+zHL47cqRRDWT6MtOoBV+cq8NxDQCbkwQyqupAXE6cNDfSJWzmipnaUKugw/gxz0e8iAgUXaJefxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "email-validator": "^1.0.7",
+        "immutable": "^3.8.1",
+        "randomstring": "^1.1.5",
+        "valid-url": "^1.0.9"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5475,6 +5498,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-fresh": {
@@ -7702,6 +7735,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomstring": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.3.1.tgz",
+      "integrity": "sha512-lgXZa80MUkjWdE7g2+PZ1xDLzc7/RokXVEQOv5NN2UOTChW1I8A9gha5a9xYBOqgaSoI6uJikDmCU8PyRdArRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "2.1.0"
+      },
+      "bin": {
+        "randomstring": "bin/randomstring"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8807,6 +8866,12 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==",
+      "dev": true
     },
     "node_modules/validator": {
       "version": "13.15.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import systemRoutes from './features/system/routes/system.routes';
 import { errorHandler } from './utils/errors/error-handler.middleware';
 import authRoutes from './features/users/routes/login.routes';
 import forgotPasswordRoutes from './features/users/routes/forgot.password.routes';
-const app = express();
+export const app = express();
 const PORT = 3000;
 
 

--- a/src/features/users/services/forgot.password.service.ts
+++ b/src/features/users/services/forgot.password.service.ts
@@ -5,22 +5,28 @@ import axios from 'axios';
 //TODO: Add error handling and logging
 //TODO: Check how tf i connect to the other microservice
 
-
-
 export async function generatePasswordResetLink(email: string): Promise<string> {
   try {
     // 1. Generate the password reset link
     const recoveryLink = await admin.auth().generatePasswordResetLink(email);
 
+    //Once its up on the server:
     // 2. Send it to MS-Notification
-    await axios.post('http://ms-notification:3001/api/email/recovery', {
+      // await axios.post('http://ms-notification:3001/send-password-reset', {
+      //   email,
+      //   recoveryLink,
+      // });
+
+    // For local testing
+    await axios.post('http://localhost:3001/send-password-reset', {
       email,
       recoveryLink,
     });
+    
 
     return `Recovery email sent to ${email}`;
   } catch (error) {
-    console.error('[generatePasswordResetLink] Error:', error);
+    console.log('[generatePasswordResetLink] Error:', error);
     throw new Error('Failed to generate or send recovery link');
   }
 }

--- a/test-api/controllers/forgot.password.controller.test.ts
+++ b/test-api/controllers/forgot.password.controller.test.ts
@@ -1,0 +1,51 @@
+import { sendRecoveryLink } from '../../src/features/users/controllers/forgot.password.controller';
+import { generatePasswordResetLink } from '../../src/features/users/services/forgot.password.service';
+
+jest.mock('../../src/features/users/services/forgot.password.service');
+const mockGeneratePasswordResetLink = generatePasswordResetLink as jest.Mock;
+
+describe('Forgot Password Controller', () => {
+  let req: any;
+  let res: any;
+
+  beforeEach(() => {
+    req = { body: {} };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and success message when email is valid', async () => {
+    const message = 'Recovery email sent to user@example.com';
+    req.body.email = 'user@example.com';
+    mockGeneratePasswordResetLink.mockResolvedValueOnce(message);
+
+    await sendRecoveryLink(req, res);
+
+    expect(mockGeneratePasswordResetLink).toHaveBeenCalledWith('user@example.com');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ message });
+  });
+
+  it('should return 400 if email is invalid', async () => {
+    req.body.email = 'not-an-email';
+
+    await sendRecoveryLink(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid email format' });
+  });
+
+  it('should return 500 and error message on failure', async () => {
+    const error = new Error('Something went wrong');
+    req.body.email = 'user@example.com';
+    mockGeneratePasswordResetLink.mockRejectedValueOnce(error);
+
+    await sendRecoveryLink(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Could not send recovery email' });
+  });
+});

--- a/test-api/dto/send-recovery-link.dto.test.ts
+++ b/test-api/dto/send-recovery-link.dto.test.ts
@@ -1,0 +1,32 @@
+import { SendRecoveryLinkDto } from '../../src/features/users/dto/send-recovery-link.dto';
+import { validate } from 'class-validator';
+
+describe('SendRecoveryLinkDto', () => {
+  it('should pass validation with a valid email', async () => {
+    const dto = new SendRecoveryLinkDto();
+    dto.email = 'user@example.com';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  it('should fail validation with an invalid email', async () => {
+    const dto = new SendRecoveryLinkDto();
+    dto.email = 'invalid-email';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('email');
+  });
+
+  it('should fail validation when email is missing', async () => {
+    const dto = new SendRecoveryLinkDto();
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('email');
+  });
+});

--- a/test-api/mocks/firebase.mock.ts
+++ b/test-api/mocks/firebase.mock.ts
@@ -1,5 +1,6 @@
 const mockAdmin = {
   auth: jest.fn().mockReturnThis(),
+  generatePasswordResetLink: jest.fn(),
   verifyIdToken: jest.fn(),
   getUser: jest.fn(),
 };

--- a/test-api/routes/forgot.password.routes.test.ts
+++ b/test-api/routes/forgot.password.routes.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import { app } from '../../src/app';
+import * as forgotService from '../../src/features/users/services/forgot.password.service';
+
+jest.mock('../../src/features/users/services/forgot.password.service');
+
+describe('POST /api/recover-password', () => {
+  const mockGenerateLink = forgotService.generatePasswordResetLink as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should respond with 200 and a success message when email is valid', async () => {
+    mockGenerateLink.mockResolvedValue('Recovery email sent to user@example.com');
+
+    const response = await request(app)
+      .post('/api/recover-password')
+      .send({ email: 'user@example.com' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: 'Recovery email sent to user@example.com',
+    });
+    expect(mockGenerateLink).toHaveBeenCalledWith('user@example.com');
+  });
+
+  it('should respond with 400 for invalid email format', async () => {
+    const response = await request(app)
+      .post('/api/recover-password')
+      .send({ email: 'not-an-email' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'Invalid email format',
+    });
+  });
+
+  it('should respond with 500 if the service throws an error', async () => {
+    mockGenerateLink.mockRejectedValue(new Error('Internal error'));
+
+    const response = await request(app)
+      .post('/api/recover-password')
+      .send({ email: 'user@example.com' });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: 'Could not send recovery email',
+    });
+  });
+});

--- a/test-api/services/forgot.password.service.test.ts
+++ b/test-api/services/forgot.password.service.test.ts
@@ -26,7 +26,7 @@ describe('generatePasswordResetLink with static mock', () => {
 
     expect(mockAdmin.auth().generatePasswordResetLink).toHaveBeenCalledWith(email);
     expect(mockedAxiosPost).toHaveBeenCalledWith(
-      'http://ms-notification:3001/api/email/recovery',
+      'http://localhost:3001/send-password-reset',
       { email, recoveryLink }
     );
     expect(result).toBe(`Recovery email sent to ${email}`);

--- a/test-api/services/forgot.password.service.test.ts
+++ b/test-api/services/forgot.password.service.test.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import mockAdmin from '../mocks/firebase.mock';
+import { generatePasswordResetLink } from '../../src/features/users/services/forgot.password.service';
+
+jest.mock('../../src/config/firebase', () => ({
+  __esModule: true,
+  default: mockAdmin,
+}));
+
+jest.mock('axios');
+const mockedAxiosPost = axios.post as jest.Mock;
+
+describe('generatePasswordResetLink with static mock', () => {
+  const email = 'user@example.com';
+  const recoveryLink = 'https://mock-reset-link.com';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should generate a password reset link and send it via MS-Notification', async () => {
+    mockAdmin.auth().generatePasswordResetLink.mockResolvedValueOnce(recoveryLink);
+    mockedAxiosPost.mockResolvedValueOnce({ status: 200 });
+
+    const result = await generatePasswordResetLink(email);
+
+    expect(mockAdmin.auth().generatePasswordResetLink).toHaveBeenCalledWith(email);
+    expect(mockedAxiosPost).toHaveBeenCalledWith(
+      'http://ms-notification:3001/api/email/recovery',
+      { email, recoveryLink }
+    );
+    expect(result).toBe(`Recovery email sent to ${email}`);
+  });
+
+  it('should throw an error if Firebase generatePasswordResetLink fails', async () => {
+    mockAdmin.auth().generatePasswordResetLink.mockRejectedValueOnce(new Error('Firebase error'));
+
+    await expect(generatePasswordResetLink(email)).rejects.toThrow('Failed to generate or send recovery link');
+    expect(mockedAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error if axios.post fails', async () => {
+    mockAdmin.auth().generatePasswordResetLink.mockResolvedValueOnce(recoveryLink);
+    mockedAxiosPost.mockRejectedValueOnce(new Error('Axios error'));
+
+    await expect(generatePasswordResetLink(email)).rejects.toThrow('Failed to generate or send recovery link');
+  });
+  
+});

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import app from '../src/app';
+import {app} from '../src/app';
 
 describe('GET /', () => {
     it('should return a 200 status and the correct message', async () => {


### PR DESCRIPTION
 Add tests for password reset email flow + fix endpoint expectation
This PR includes:

Unit tests for the generatePasswordResetLink logic using mocked Firebase and Axios

Fix to ensure the test uses the correct endpoint: http://localhost:3001/send-password-reset

Verifies email content and link dispatch response

Thanks QA for letting me upload the tests later, won't happen again.