### PR TITLE
Feature/cu 86a7ky9pz send recover password link

### DIFF
--- a/src/features/users/controllers/forgot.password.controller.ts
+++ b/src/features/users/controllers/forgot.password.controller.ts
@@ -9,7 +9,7 @@ export const sendRecoveryLink = async (req: Request, res: Response): Promise<voi
   const errors = await validate(dto);
 
   if (errors.length > 0) {
-    res.status(400).json({ error: 'Invalid email format' });
+    res.status(400).json({ error: 'Formato de email incorrecto. Asegurate que sea el correo institucional.' });
     return;
   }
 
@@ -18,6 +18,6 @@ export const sendRecoveryLink = async (req: Request, res: Response): Promise<voi
     res.status(200).json({ message: result });
   } catch (err) {
     console.error('[Error sending recovery link]', err);
-    res.status(500).json({ error: 'Could not send recovery email' });
+    res.status(500).json({ error: 'No se logró enviar el correo de recuperación. Verifica que el correo sea el correcto.' });
   }
 };

--- a/src/features/users/dto/send-recovery-link.dto.ts
+++ b/src/features/users/dto/send-recovery-link.dto.ts
@@ -1,8 +1,10 @@
-// send-recovery-link.dto.ts
-import { IsEmail, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty, Matches } from 'class-validator';
 
 export class SendRecoveryLinkDto {
   @IsEmail()
   @IsNotEmpty()
+  @Matches(/^[\w.-]+@ucr\.ac\.cr$/, {
+    message: 'El correo electrónico debe ser institucional (@ucr.ac.cr)',
+  })
   email!: string;
 }

--- a/src/features/users/services/forgot.password.service.ts
+++ b/src/features/users/services/forgot.password.service.ts
@@ -10,23 +10,16 @@ export async function generatePasswordResetLink(email: string): Promise<string> 
     // 1. Generate the password reset link
     const recoveryLink = await admin.auth().generatePasswordResetLink(email);
 
-    //Once its up on the server:
-    // 2. Send it to MS-Notification
-      // await axios.post('http://ms-notification:3001/send-password-reset', {
-      //   email,
-      //   recoveryLink,
-      // });
 
-    // For local testing
-    await axios.post('http://localhost:3001/send-password-reset', {
+    await axios.post(' http://157.230.224.13:3002/api/email/send-password-reset', {
       email,
       recoveryLink,
     });
     
 
-    return `Recovery email sent to ${email}`;
+    return `Se envio el correo de recuperación a ${email}.Sigue las instrucciones en el correo para restablecer tu contraseña.`;
   } catch (error) {
     console.log('[generatePasswordResetLink] Error:', error);
-    throw new Error('Failed to generate or send recovery link');
+    throw new Error('El correo electrónico no es válido o no está registrado.');
   }
 }


### PR DESCRIPTION
fix(auth): enforce @ucr.ac.cr email and localize errors to Spanish

- Added regex validation to only allow emails ending with @ucr.ac.cr
- Updated error messages to display in Spanish
- Fixed the recovery password endpoint route
