### PR TITLE
Feature/add email jwt

### DIFF
--- a/src/features/middleware/authenticate.middleware.ts
+++ b/src/features/middleware/authenticate.middleware.ts
@@ -29,6 +29,11 @@ export const authenticateJWT = (req: Request, res: Response, next: NextFunction)
 
     // Validate and set role to either 'user' or 'admin'
     const validRole = decoded.role === 'admin' ? 'admin' : 'user';
+    const email = decoded.email;
+
+    if (!email) {
+      throw new UnauthorizedError('Unauthorized', ['Not registered user']);
+    }
     
     // Convertimos el req a AuthenticatedRequest al inyectar la propiedad user
     (req as AuthenticatedRequest).user = {

--- a/src/features/users/services/jwt.service.ts
+++ b/src/features/users/services/jwt.service.ts
@@ -7,6 +7,8 @@ dotenv.config();
 
 interface Payload {
   role: string;
+  email: string; // For future request to database based on email
+  uuid: string;
 }
 
 export class JwtService {
@@ -30,6 +32,14 @@ export class JwtService {
       // Validate role is either 'user' or 'admin'
       if (decoded.role !== 'user' && decoded.role !== 'admin') {
         throw new UnauthorizedError('Invalid role in token');
+      }
+
+      if (!decoded.email) {
+        throw new UnauthorizedError('Unauthorized', ['Not registered user']);
+      }
+
+      if (!decoded.uuid) {
+        throw new UnauthorizedError('Unauthorized', ['Not registered user']);
       }
       return decoded;
     } catch (error) {

--- a/src/features/users/services/login.service.ts
+++ b/src/features/users/services/login.service.ts
@@ -25,10 +25,20 @@ export const loginUserService = async (firebaseToken: string) => {
       throw new UnauthorizedError('Unauthorized', ['Not registered user']);
     }
 
+    if (!existingUser.is_active) {
+      throw new UnauthorizedError('Unauthorized', ['User is inactive']);
+    }
+
+    if (existingUser.id === null) {
+      throw new UnauthorizedError('Unauthorized', ['Not registered user']);
+    }
+
     // Generate JWT token
     const jwtService = new JwtService();
     const token = jwtService.generateToken({
-      role: 'user'
+      role: 'user',
+      email: email, // Include email in the token payload for future requests
+      uuid: existingUser.id // Include UUID in the token payload for future requests
     });
 
     return {
@@ -62,13 +72,23 @@ export const loginAdminService = async (firebaseToken: string) => {
     if (!existingAdmin) {
       throw new UnauthorizedError('Unauthorized', ['Not registered admin']);
     }
+
+    if (!existingAdmin.is_active) {
+      throw new UnauthorizedError('Unauthorized', ['User is inactive']);
+    }
+
+    if (existingAdmin.id === null) {
+      throw new UnauthorizedError('Unauthorized', ['Not registered user']);
+    }
     
-    console.log('Successful verification. Admin:', decoded.uid, 'Email:', email);
+    console.log('Successful verification. Admin:', decoded.uid, 'Email:', email, existingAdmin.id);
 
     // Generate JWT token
     const jwtService = new JwtService();
     const token = jwtService.generateToken({
-      role: 'admin'
+      role: 'admin',
+      email: email, // Include email in the token payload for future requests
+      uuid: existingAdmin.id // Include UUID in the token payload for future requests
     });
 
     return {

--- a/test-api/middleware/authenticate.middleware.test.ts
+++ b/test-api/middleware/authenticate.middleware.test.ts
@@ -76,7 +76,7 @@ describe('Authentication Middleware', () => {
 
     it('should set user role to admin when token is valid with admin role', () => {
       mockRequest.headers = { authorization: 'Bearer validToken' };
-      const mockDecodedToken = { role: 'admin' };
+      const mockDecodedToken = { role: 'admin', email: 'example@ucr.ac.cr', uuid: '123456789101' };
       
       (JwtService.prototype.verifyToken as jest.Mock).mockReturnValue(mockDecodedToken);
 
@@ -92,7 +92,7 @@ describe('Authentication Middleware', () => {
 
     it('should set user role to user when token is valid with non-admin role', () => {
       mockRequest.headers = { authorization: 'Bearer validToken' };
-      const mockDecodedToken = { role: 'user' };
+      const mockDecodedToken = { role: 'user', email: 'example@ucr.ac.cr', uuid: '123456789101' };
       
       (JwtService.prototype.verifyToken as jest.Mock).mockReturnValue(mockDecodedToken);
 

--- a/test-api/services/jwt.service.test.ts
+++ b/test-api/services/jwt.service.test.ts
@@ -1,3 +1,4 @@
+import jwt from 'jsonwebtoken';
 import { JwtService } from '../../src/features/users/services/jwt.service';
 import { UnauthorizedError } from '../../src/utils/errors/api-error';
 
@@ -10,19 +11,59 @@ describe('JwtService', () => {
   });
 
   it('should generate a valid token', () => {
-    const payload = {role: 'user' , email: 'example@ucr.ac.cr', uuid: '123456789101'};
+    const payload = { role: 'user', email: 'example@ucr.ac.cr', uuid: '123456789101' };
     const token = jwtService.generateToken(payload);
     expect(typeof token).toBe('string');
   });
 
   it('should verify a valid token', () => {
-    const payload = {role: 'user' , email: 'example@ucr.ac.cr', uuid: '123456789101'};
+    const payload = { role: 'user', email: 'example@ucr.ac.cr', uuid: '123456789101' };
     const token = jwtService.generateToken(payload);
     const decoded = jwtService.verifyToken(token);
-    expect(decoded).toMatchObject(payload); // Verifica solo las propiedades relevantes
+    expect(decoded).toMatchObject(payload);
   });
 
   it('should throw UnauthorizedError for an invalid token', () => {
     expect(() => jwtService.verifyToken('invalidToken')).toThrow(UnauthorizedError);
+  });
+
+  it('should throw UnauthorizedError for an expired token', () => {
+    const payload = { role: 'user', email: 'example@ucr.ac.cr', uuid: '123456789101' };
+    const token = jwt.sign(payload, process.env.JWT_SECRET as string, { expiresIn: '1ms' });
+    setTimeout(() => {
+      expect(() => jwtService.verifyToken(token)).toThrow(UnauthorizedError);
+    }, 10);
+  });
+
+  it('should throw UnauthorizedError if the role is invalid', () => {
+    const payload = { role: 'invalidRole', email: 'example@ucr.ac.cr', uuid: '123456789101' };
+    const token = jwt.sign(payload, process.env.JWT_SECRET as string, { expiresIn: '1h' });
+    expect(() => jwtService.verifyToken(token)).toThrow(UnauthorizedError);
+  });
+
+  it('should throw UnauthorizedError if the email is missing', () => {
+    const payload = { role: 'user', uuid: '123456789101' };
+    const token = jwt.sign(payload, process.env.JWT_SECRET as string, { expiresIn: '1h' });
+    expect(() => jwtService.verifyToken(token)).toThrow(UnauthorizedError);
+  });
+
+  it('should throw UnauthorizedError if the uuid is missing', () => {
+    const payload = { role: 'user', email: 'example@ucr.ac.cr' };
+    const token = jwt.sign(payload, process.env.JWT_SECRET as string, { expiresIn: '1h' });
+    expect(() => jwtService.verifyToken(token)).toThrow(UnauthorizedError);
+  });
+
+  it('should throw an error if JWT_SECRET is not defined', () => {
+    delete process.env.JWT_SECRET;
+    expect(() => new JwtService()).toThrow('JWT_SECRET is not defined in environment variables');
+  });
+
+  it('should generate a token with a 1-hour expiration', () => {
+    const payload = { role: 'user', email: 'example@ucr.ac.cr', uuid: '123456789101' };
+    const token = jwtService.generateToken(payload);
+    const decoded = jwt.decode(token) as any;
+    const currentTime = Math.floor(Date.now() / 1000);
+    expect(decoded.exp).toBeGreaterThan(currentTime);
+    expect(decoded.exp).toBeLessThanOrEqual(currentTime + 3600);
   });
 });

--- a/test-api/services/jwt.service.test.ts
+++ b/test-api/services/jwt.service.test.ts
@@ -10,13 +10,13 @@ describe('JwtService', () => {
   });
 
   it('should generate a valid token', () => {
-    const payload = {role: 'user' };
+    const payload = {role: 'user' , email: 'example@ucr.ac.cr', uuid: '123456789101'};
     const token = jwtService.generateToken(payload);
     expect(typeof token).toBe('string');
   });
 
   it('should verify a valid token', () => {
-    const payload = { role: 'user' };
+    const payload = {role: 'user' , email: 'example@ucr.ac.cr', uuid: '123456789101'};
     const token = jwtService.generateToken(payload);
     const decoded = jwtService.verifyToken(token);
     expect(decoded).toMatchObject(payload); // Verifica solo las propiedades relevantes

--- a/test-api/services/login.service.test.ts
+++ b/test-api/services/login.service.test.ts
@@ -44,19 +44,24 @@ describe('Auth Service', () => {
       await expect(loginUserService('token-without-email')).rejects.toThrow(UnauthorizedError);
     });
 
-    it('should return a JWT token containing only role=user', async () => {
+    it('should return a JWT token containing role=user, containing uuid and email', async () => {
       mockVerifyIdToken.mockResolvedValueOnce({ email: 'user@ucr.ac.cr', uid: 'user123' });
-      (findByEmailUser as jest.Mock).mockResolvedValueOnce({ id: '123', email: 'user@ucr.ac.cr' });
+      (findByEmailUser as jest.Mock).mockResolvedValueOnce({ id: '123', email: 'user@ucr.ac.cr', is_active: true});
 
       const result = await loginUserService('valid-token');
 
       expect(result).toHaveProperty('access_token');
       expect(typeof result.access_token).toBe('string');
 
-      const decoded = jwt.decode(result.access_token) as { role: string };
+      const decoded = jwt.decode(result.access_token) as 
+      { 
+        role: string,
+        email: string,
+        uuid: string
+      };
       expect(decoded.role).toBe('user');
-      expect(decoded).not.toHaveProperty('email');
-      expect(decoded).not.toHaveProperty('uid');
+      expect(decoded).toHaveProperty('email');
+      expect(decoded).toHaveProperty('uuid');
     });
   });
 
@@ -80,19 +85,24 @@ describe('Auth Service', () => {
       await expect(loginAdminService('token-without-email')).rejects.toThrow(UnauthorizedError);
     });
 
-    it('should return a JWT token containing only role=admin', async () => {
+    it('should return a JWT token containing role=admin, containing uuid and email', async () => {
       mockVerifyIdToken.mockResolvedValueOnce({ email: 'admin@ucr.ac.cr', uid: 'admin123' });
-      (findByEmailAdmin as jest.Mock).mockResolvedValueOnce({ id: 'admin123', email: 'admin@ucr.ac.cr' });
+      (findByEmailAdmin as jest.Mock).mockResolvedValueOnce({ id: '123', email: 'admin@ucr.ac.cr', is_active: true});
 
       const result = await loginAdminService('valid-token');
 
       expect(result).toHaveProperty('access_token');
       expect(typeof result.access_token).toBe('string');
 
-      const decoded = jwt.decode(result.access_token) as { role: string };
+      const decoded = jwt.decode(result.access_token) as 
+      { 
+        role: string,
+        email: string,
+        uuid: string
+      };
       expect(decoded.role).toBe('admin');
-      expect(decoded).not.toHaveProperty('email');
-      expect(decoded).not.toHaveProperty('uid');
+      expect(decoded).toHaveProperty('email');
+      expect(decoded).toHaveProperty('uuid');
     });
   });
 


### PR DESCRIPTION
This pull request enhances the JWT authentication system by including additional user information **(`email` and `uuid`)** in the token payload and implementing stricter validation checks.

**THE MOST IMPORTANT: Including email and uuid in a JWT allows us to use this information in other microservices that require the email or uuid for database queries.**

## Description of changes
### Authentication Enhancements:
* Added `email` and `uuid` to the JWT payload for future database-related operations. (`src/features/users/services/jwt.service.ts`) [[1]](diffhunk://#diff-822a8027f7736983b521572ef09141c54a4ad28b8c1cedd615bc1da613ac022fR10-R11) [[2]](diffhunk://#diff-d9b1525e022407f7ee24956c4059834456653b93b1459260395010307d90ec4eR28-R41) [[3]](diffhunk://#diff-d9b1525e022407f7ee24956c4059834456653b93b1459260395010307d90ec4eL66-R91)
* Introduced validation checks in the `JwtService` and `authenticateJWT` middleware to ensure `email` and `uuid` are present in the token, throwing an `UnauthorizedError` if missing. (`src/features/users/services/jwt.service.ts`, `src/features/middleware/authenticate.middleware.ts`) [[1]](diffhunk://#diff-822a8027f7736983b521572ef09141c54a4ad28b8c1cedd615bc1da613ac022fR36-R43) [[2]](diffhunk://#diff-3d3278b88cdf609d10e377615a5c4c3b61dcaefd4b725d8d0e68edba0de7489dR32-R36)

### User and Admin Login Enhancements:
* Enhanced `loginUserService` and `loginAdminService` to include `email` and `uuid` in the generated JWT token. Added checks for inactive users and null user IDs. (`src/features/users/services/login.service.ts`) [[1]](diffhunk://#diff-d9b1525e022407f7ee24956c4059834456653b93b1459260395010307d90ec4eR28-R41) [[2]](diffhunk://#diff-d9b1525e022407f7ee24956c4059834456653b93b1459260395010307d90ec4eL66-R91)

### Test Updates:
* Updated unit tests for `JwtService`, `authenticateJWT`, and login services to validate the presence of `email` and `uuid` in tokens. (`test-api/services/jwt.service.test.ts`, `test-api/middleware/authenticate.middleware.test.ts`, `test-api/services/login.service.test.ts`) [[1]](diffhunk://#diff-a9a0901c9e13af35c588e1aa42e4428e3f134a929e95b9318b67b722904aa7c9L13-R19) [[2]](diffhunk://#diff-0384e7a46c2728fe8f3e296bde6b037a8f120b5fb50e2d590f4d4cd9533bfe49L79-R79) [[3]](diffhunk://#diff-0384e7a46c2728fe8f3e296bde6b037a8f120b5fb50e2d590f4d4cd9533bfe49L95-R95) [[4]](diffhunk://#diff-d3501a85722594bf5bd04b5da9b3561d4475db3629c88d81803688ad0f05902aL47-R64) [[5]](diffhunk://#diff-d3501a85722594bf5bd04b5da9b3561d4475db3629c88d81803688ad0f05902aL83-R105)