### PR TITLE
feat: default profile picture when profile_picture request is null

### DIFF
--- a/src/features/users/dto/profile.dto.ts
+++ b/src/features/users/dto/profile.dto.ts
@@ -22,6 +22,10 @@ export const updateUserProfileSchema = yup.object({
     )
     .optional(),
 
+  profile_picture: yup
+    .mixed()
+    .nullable()
+    .optional()
 });
 
 export const updateAdminProfileSchema = yup.object({
@@ -35,6 +39,11 @@ export const updateAdminProfileSchema = yup.object({
       'El nombre completo solo puede contener letras y espacios'
     )
     .optional(),
+    
+  profile_picture: yup
+    .mixed()
+    .nullable()
+    .optional()
 });
 
 export type UpdateUserProfileDTO = yup.InferType<typeof updateUserProfileSchema>;

--- a/src/features/users/services/profile.service.ts
+++ b/src/features/users/services/profile.service.ts
@@ -7,6 +7,7 @@ import { UpdateUserProfileDTO, UpdateAdminProfileDTO } from "../dto/profile.dto"
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 import { logProfileUpdate } from './audit.service';
+import { DEFAULT_PROFILE_PICTURE } from '../../../utils/constants/image';
 
 export const getUserProfileService = async (email: string) => {
   const user = await findByEmailUser(email);
@@ -109,17 +110,19 @@ export const updateUserProfileService = async (email: string, tokenAuth: string,
       updateFields.full_name = updateData.full_name;
     }
 
-    if (fileBuffer && fileName && fileMimeType) {
+    if (updateData.profile_picture === null) {
+      updateFields.profile_picture = DEFAULT_PROFILE_PICTURE;
+    } else if (fileBuffer && fileName && fileMimeType) {
       updateFields.profile_picture = await uploadProfileImage(fileBuffer, fileName, fileMimeType, tokenAuth, user.profile_picture, user.id);
     }
     // Verificar si hay campos para actualizar
     if (Object.keys(updateFields).length === 0) {
       throw new BadRequestError("No fields to update provided", ["Provide at least one field to update"]);
     }
- // Guardar valores actuales antes de la actualización para la auditoría
+    // Guardar valores actuales antes de la actualización para la auditoría
     const oldValues: Record<string, any> = {};
     const changedFields: string[] = [];
-    
+
     Object.keys(updateFields).forEach(field => {
       if (user[field as keyof typeof user] !== updateFields[field as keyof typeof updateFields]) {
         oldValues[field] = user[field as keyof typeof user];
@@ -175,7 +178,7 @@ export const updateAdminProfileService = async (email: string, tokenAuth: string
   try {
 
     const admin = await findByEmailAdmin(email);
-  
+
     if (!admin) {
       throw new NotFoundError("Admin not found");
     }
@@ -186,7 +189,9 @@ export const updateAdminProfileService = async (email: string, tokenAuth: string
       updateFields.full_name = updateData.full_name;
     }
 
-    if (fileBuffer && fileName && fileMimeType) {
+    if (updateData.profile_picture === null) {
+      updateFields.profile_picture = DEFAULT_PROFILE_PICTURE;
+    } else if (fileBuffer && fileName && fileMimeType) {
       updateFields.profile_picture = await uploadProfileImage(fileBuffer, fileName, fileMimeType, tokenAuth, admin.profile_picture, admin.id);
     }
 

--- a/src/features/users/services/register.service.ts
+++ b/src/features/users/services/register.service.ts
@@ -4,10 +4,11 @@ import { createUser, findByEmailUser } from '../repositories/user.repository';
 import { createAdmin, findByEmailAdmin} from '../repositories/admin.repository';
 // import { sendVerificationEmail } from '../../../utils/notificationClient';
 import { v4 as uuidv4 } from 'uuid';
-import { UnauthorizedError, ConflictError, InternalServerError } from '../../../utils/errors/api-error';
+import { UnauthorizedError, ConflictError, InternalServerError } 
+from '../../../utils/errors/api-error';
+import { DEFAULT_PROFILE_PICTURE } from '../../../utils/constants/image';
 import axios from 'axios';
 
-const DEFAULT_PROFILE_PICTURE = 'https://utfs.io/f/Ri7z8Bp5Nkcu6mKIWdaT84vfYJdV9XQeAOZqrItaMwWcxbph';  // Update with your actual default image URL
 
 async function sendRegistrationConfirmation(email: string, fullName: string, userType: 'mobile' | 'web') {
   try {

--- a/src/utils/constants/image.ts
+++ b/src/utils/constants/image.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_PROFILE_PICTURE = 'https://utfs.io/f/Ri7z8Bp5Nkcu6mKIWdaT84vfYJdV9XQeAOZqrItaMwWcxbph';
+
+export const MAX_PROFILE_IMAGE_SIZE = 4 * 1024 * 1024; // 4MB


### PR DESCRIPTION
## Type of change
[x] feat

## Description
This PR enhances the profile management system by adding support for resetting profile pictures to a default value when `null` is explicitly sent in profile update requests for both user and admin profiles.

## Changes Made

### In profile.service.ts:
- Added conditional logic in `updateUserProfileService` and `updateAdminProfileService` to detect when `profile_picture` is explicitly set to `null` and replace it with the default image URL: 

### In profile.dto.ts:
- Updated DTOs to allow `null` values for `profile_picture` field:

## Testing

Postman
