### PR TITLE
Add profile picture in repository to admins

### DIFF
--- a/src/features/users/repositories/admin.repository.ts
+++ b/src/features/users/repositories/admin.repository.ts
@@ -8,9 +8,9 @@ export const findByEmailAdmin = async (email: string) => {
 
 export const createAdmin = async (admin: AdminUser) => {
   const result = await client.query(`
-    INSERT INTO admin_users (id, email, full_name, auth_id, is_active, created_at)
-    VALUES ($1, $2, $3, $4, $5, NOW())`,
-    [admin.id, admin.email, admin.full_name, admin.auth_id, admin.is_active]
+    INSERT INTO admin_users (id, email, full_name, auth_id, profile_picture, is_active, created_at)
+    VALUES ($1, $2, $3, $4, $5, $6, NOW())`,
+    [admin.id, admin.email, admin.full_name, admin.auth_id, admin.profile_picture,admin.is_active]
   );
   return result.rows[0];
 };

--- a/src/utils/constants/image.ts
+++ b/src/utils/constants/image.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_PROFILE_PICTURE = 'https://okql30oeeh.ufs.sh/f/Ri7z8Bp5Nkcu1UOzveA2kFsLQGZrSmEAD8TUPpWcfw5Vq3R0';
+export const DEFAULT_PROFILE_PICTURE = 'https://utfs.io/f/Ri7z8Bp5NkcuKusSJHzg7svjdQTeVIL2qyOpRG9W4XnzUto6';
 
 export const MAX_PROFILE_IMAGE_SIZE = 4 * 1024 * 1024; // 4MB

--- a/test-api/repositories/admin.repository.test.ts
+++ b/test-api/repositories/admin.repository.test.ts
@@ -88,7 +88,7 @@ describe('Admin Repository', () => {
       
       expect(mockClient.query).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO admin_users'),
-        [newAdmin.id, newAdmin.email, newAdmin.full_name, newAdmin.auth_id, newAdmin.is_active]
+        [newAdmin.id, newAdmin.email, newAdmin.full_name, newAdmin.auth_id, newAdmin.profile_picture, newAdmin.is_active]
       );
     });
 


### PR DESCRIPTION
## Desciption
This PR enhances the admin user creation process by ensuring that a default profile picture is assigned to newly created admin accounts. It also updates the default profile picture URL used throughout the application.

## Changes Made

### 1. Updated Default Profile Picture
- Updated the default profile picture URL constant in image.ts
- Changed from previous URL to the new UploadThing URL: `https://utfs.io/f/Ri7z8Bp5NkcuKusSJHzg7svjdQTeVIL2qyOpRG9W4XnzUto6`

### 2. Enhanced Admin Creation Process
- Modified the admin creation flow to include profile picture assignment

## Testing
- Verified that new admin accounts are created with the default profile picture
- Confirmed that profile picture resets properly use the default image
