### PR TITLE
Restrict access on suspended accounts | User Microservices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4492,6 +4492,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cls-hooked": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",

--- a/src/features/users/repositories/suspension.repository.ts
+++ b/src/features/users/repositories/suspension.repository.ts
@@ -24,3 +24,16 @@ export const findSuspensionById = async (id: string) => {
   );
   return result.rows[0];
 };
+
+export const isUserSuspended = async (userId: string): Promise<boolean> => {
+  const query = `
+    SELECT 1
+    FROM user_suspensions
+    WHERE user_id = $1
+      AND start_date <= NOW()
+      AND end_date > NOW()
+    LIMIT 1;
+  `;
+  const result = await client.query(query, [userId]);
+  return result.rows.length > 0;
+};

--- a/test-api/middleware/authenticate.middleware.test.ts
+++ b/test-api/middleware/authenticate.middleware.test.ts
@@ -12,6 +12,10 @@ import { authenticateJWT, validateAuth } from '../../src/features/middleware/aut
 import { JwtService } from '../../src/features/users/services/jwt.service';
 import { UnauthorizedError } from '../../src/utils/errors/api-error';
 
+jest.mock('../../src/features/users/repositories/suspension.repository', () => ({
+  isUserSuspended: jest.fn().mockResolvedValue(false),
+}));
+
 describe('Authentication Middleware', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
@@ -74,13 +78,13 @@ describe('Authentication Middleware', () => {
       expect(error.message).toBe('Invalid token format');
     });
 
-    it('should set user role to admin when token is valid with admin role', () => {
+    it('should set user role to admin when token is valid with admin role', async () => {
       mockRequest.headers = { authorization: 'Bearer validToken' };
       const mockDecodedToken = { role: 'admin', email: 'example@ucr.ac.cr', uuid: '123456789101' };
       
       (JwtService.prototype.verifyToken as jest.Mock).mockReturnValue(mockDecodedToken);
 
-      authenticateJWT(
+      await authenticateJWT(
         mockRequest as Request,
         mockResponse as Response,
         nextFunction
@@ -90,13 +94,13 @@ describe('Authentication Middleware', () => {
       expect((mockRequest as any).user.role).toBe('admin');
     });
 
-    it('should set user role to user when token is valid with non-admin role', () => {
+    it('should set user role to user when token is valid with non-admin role', async () => {
       mockRequest.headers = { authorization: 'Bearer validToken' };
       const mockDecodedToken = { role: 'user', email: 'example@ucr.ac.cr', uuid: '123456789101' };
       
       (JwtService.prototype.verifyToken as jest.Mock).mockReturnValue(mockDecodedToken);
 
-      authenticateJWT(
+      await authenticateJWT(
         mockRequest as Request,
         mockResponse as Response,
         nextFunction
@@ -106,13 +110,13 @@ describe('Authentication Middleware', () => {
       expect((mockRequest as any).user.role).toBe('user');
     });
 
-    it('should throw UnauthorizedError when token is valid but missing email', () => {
+    it('should throw UnauthorizedError when token is valid but missing email', async () => {
       mockRequest.headers = { authorization: 'Bearer validToken' };
       const mockDecodedToken = { role: 'user', uuid: '123456789101' }; // no email
 
       (JwtService.prototype.verifyToken as jest.Mock).mockReturnValue(mockDecodedToken);
 
-      authenticateJWT(
+      await authenticateJWT(
         mockRequest as Request,
         mockResponse as Response,
         nextFunction

--- a/test-api/repositories/userSuspension.repository.test.ts
+++ b/test-api/repositories/userSuspension.repository.test.ts
@@ -1,0 +1,34 @@
+import { isUserSuspended } from '../../src/features/users/repositories/suspension.repository';
+import client from '../../src/config/database';
+import { QueryResult } from 'pg';
+
+jest.mock('../../src/config/database', () => ({
+    query: jest.fn(),
+}));
+
+const mockClient = client as unknown as { query: jest.Mock };
+
+describe('isUserSuspended', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return true when an active suspension exists', async () => {
+        const mockResult = { rows: [{ id: '1' }] } as QueryResult;
+        mockClient.query.mockResolvedValueOnce(mockResult);
+
+        const result = await isUserSuspended('user-uuid');
+
+        expect(mockClient.query).toHaveBeenCalledWith(expect.any(String), ['user-uuid']);
+        expect(result).toBe(true);
+    });
+
+    it('should return false when no active suspension exists', async () => {
+        mockClient.query.mockResolvedValueOnce({ rows: [] } as QueryResult);
+
+        const result = await isUserSuspended('user-uuid');
+
+        expect(mockClient.query).toHaveBeenCalledWith(expect.any(String), ['user-uuid']);
+        expect(result).toBe(false);
+    });
+});


### PR DESCRIPTION
## Restrict access on suspended accounts | Post Microservices

---

Implemented a checkUserSuspension middleware that looks up the user’s account status and throws a ForbiddenError when the account is suspended

Added an isUserSuspended repository function to query user_suspensions for active suspensions

Applied the new middleware to comment, post, reportedPost, and report route handlers so suspended users are blocked from these endpoints

Added Jest unit tests covering the middleware logic and the repository query

---

This feature might be implemented on all Microservices, therefore at this point Posts and User Microservices are priorized,